### PR TITLE
First pass at item collections

### DIFF
--- a/drawable.lua
+++ b/drawable.lua
@@ -109,6 +109,10 @@ function drawable:draw(x, y, s, nx, ny, nw, nh)
 	end
 end
 
+function drawable:drawSubText(text, x, y, s)
+	love.graphics.print(text, x + (self.xOffset + self.translationXOffset + self.mapTranslationXOffset)*s, y + (self.yOffset + self.translationYOffset + self.mapTranslationYOffset)*s, 0, s)
+end
+
 function drawable:recalculateOffsets()
 	self.xOffset = TILE_SIZE*self.width - self.spriteWidth
 	self.yOffset = TILE_SIZE*self.height - self.spriteHeight

--- a/gamestate/gamestate_inventory.lua
+++ b/gamestate/gamestate_inventory.lua
@@ -42,7 +42,7 @@ function gamestate.static:getInventoryState(source, destination)
 		drawRect(gself.leftMargin, gself.topMargin, gself.width, gself.height)
 		love.graphics.print(gself.headerText, gself.headerPos, gself.topMargin + 20)
 		for i, item in ipairs(gself.items) do
-			love.graphics.print(item.name, gself.leftMargin + 20, gself.topMargin + 20 + (gself.textHeight + 5)*i)
+			love.graphics.print(item.name.."("..item.amount..")", gself.leftMargin + 20, gself.topMargin + 20 + (gself.textHeight + 5)*i)
 		end
 	end
 

--- a/gamestate/gamestate_map.lua
+++ b/gamestate/gamestate_map.lua
@@ -42,6 +42,10 @@ local function keypressed(gself, key)
 			gself.ghost:place()
 		end
 	end
+
+	if key =='t' and i and gself.map:getMouseSelection():isType("item") then
+		gself.map:getMouseSelection():mergeWith(i)
+	end
 end
 
 local function mousereleased(gself, x, y, button)

--- a/main.lua
+++ b/main.lua
@@ -79,6 +79,8 @@ function love.load()
 	local chicken = item:new("yummy chicken", m, 2, 7)
 	local pizza = item:new("yummy pizza", m, 3, 8)
 	local pizza2 = item:new("yummy pizza", m, 3, 8)
+	pizza.amount = 10
+	pizza2.amount = pizza2.maxStack - 5
 	m:addItem(chicken)
 	m:addItem(pizza)
 	m:addItem(pizza2)
@@ -202,21 +204,23 @@ function love.keypressed(key)
 		gameSpeed = clamp(gameSpeed - 1, 1, 3)
 	end
 
-	--[[
-		if key == 'e' and getMouseSelection() then
-			local e = getMouseSelection()
-			local dist = math.sqrt((t.x - e.x)^2 + (t.y - e.y)^2)
-			local function moveFunc(eself, x)
-				local p = eself.moveFuncParams
-				--p.smoothstep = true
-				
-				local y = -math.sin(math.pi*(1-p.percentComplete))*math.abs(p.tileDistance*5)
-				--local y = 0
-				return y
-			end
-			getMouseSelection():translate(t.x, t.y, 30*math.sqrt(dist), moveFunc)
+	local gs = gamestate:peek()
+
+	if key == 'e' and gs.map:getMouseSelection() then
+		local e = gs.map:getMouseSelection()
+		local t = gs.map:getTileAtWorld(getMousePos(gs.map.camera))
+		local dist = math.sqrt((t.x - e.x)^2 + (t.y - e.y)^2)
+		local function moveFunc(eself, x)
+			local p = eself.moveFuncParams
+			p.smoothstep = true
+			
+			local y = -math.sin(math.pi*(1-p.percentComplete))*math.abs(p.tileDistance*5)
+			--local y = 0
+			return y
 		end
-	]]
+		gs.map:getMouseSelection():translate(t.x, t.y, 30*math.sqrt(dist), moveFunc)
+	end
+
 end
 
 function love.wheelmoved(x, y)

--- a/map/map.lua
+++ b/map/map.lua
@@ -222,6 +222,16 @@ function map:addItem(i)
 	table.insert(self.items, i)
 end
 
+function map:removeItem(i)
+	for idx, item in ipairs(self.items) do
+		if i.uid == item.uid then
+			table.remove(self.items, idx)
+			return true
+		end
+	end
+	return false
+end
+
 function map:addFurniture(f)
 	f.map = self
 	f.x = f.x + self.xOffset


### PR DESCRIPTION
Items default to an amount of 1 and a maximum stack size of 50
Dropping items on the ground will merge stacks if possible, and move any excess to a nearby empty tile
Added drawable:drawSubText() for drawing text under a sprite, implementation needs some work
	-- Either increase font size rather than scaling (it gets very fuzzy when zoomed)
	-- or settle on a fixed font size and translate it based on scale without increasing its size
Added map:removeItem() to remove reference to loaded item