### PR TITLE
Add playerstate gamestate to handle the player's view

### DIFF
--- a/context.lua
+++ b/context.lua
@@ -9,10 +9,8 @@ local bottomPadding = 3
 local textTopPadding = 5
 local textInnerPadding = 3
 
-function context:initialize(map, font)
-	font = font or love.graphics.getFont()
-	self.map = map
-	self.font = font
+function context:initialize(state)
+	self.state = state
 	self.color = {r=0.0, g=0.0, b=0.0, a=1.0}
 end
 
@@ -28,7 +26,7 @@ function context:update()
 			local right = self.x + self.txtWidth + falloff - mx
 			local bottom = self.y + self.txtHeight + falloff - my
 			local dx, dy = 0, 0
-			
+
 			if left > 0 then dx = left end
 			if right < 0 then dx = right end
 			if top > 0 then dy = top end
@@ -90,7 +88,6 @@ function context:set(x, y, items)
 			txt = item:getContext()
 		end
 	end
-	love.graphics.setFont(self.font)
 	self.txtWidth = love.graphics.getFont():getWidth(txt)
 	self.fontHeight = love.graphics:getFont():getHeight()
 	self.txtHeight = (#items)*(self.fontHeight + textTopPadding) + bottomPadding
@@ -113,9 +110,9 @@ function context:handleClick(x, y)
 	for i, item in ipairs(self.items) do
 		if self:inBounds(x, y, item) then
 			if love.keyboard.isDown('lshift') then
-				self.map:getMouseSelection():queueTask(item)
+				self.state:getSelection():queueTask(item)
 			else
-				self.map:getMouseSelection():setTask(item)
+				self.state:getSelection():setTask(item)
 			end
 			self:clear()
 		end
@@ -155,11 +152,7 @@ function context:drawMenuItem(item, index)
 		drawRect(item.left, item.top, item.right, item.bottom, self.color)
 	end
 
-	love.graphics.setFont(self.font)
-	love.graphics.setColor(1, 1, 1, self.color.a)
 	love.graphics.print(item:getContext(), item.left + textInnerPadding, item.top)
-	love.graphics.reset()
-
 end
 
 return context

--- a/data.lua
+++ b/data.lua
@@ -2,7 +2,7 @@ local class = require('lib.middleclass')
 local utils = require('utils')
 local drawable = require('drawable')
 local item = require('items.item')
-local entity = require('entity')
+local entity = require('entities.entity')
 local furniture = require('furniture.furniture')
 local tile = require('tile')
 

--- a/drawable.lua
+++ b/drawable.lua
@@ -101,7 +101,12 @@ function drawable:draw(x, y, s, r, nx, ny, nw, nh)
 		love.graphics.draw(self.tileset, self.sprite, math.floor(x), math.floor(y), r, s)
 		self.sprite:setViewport(ox, oy, ow, oh, self.tileset:getWidth(), self.tileset:getHeight())
 	else
-		love.graphics.draw(self.tileset, self.sprite, math.floor(x), math.floor(y), r, s)
+		if r == 0 then
+			love.graphics.draw(self.tileset, self.sprite, math.floor(x), math.floor(y), r, s)
+		elseif r == math.pi/2 then
+			local ox = self.spriteWidth
+			love.graphics.draw(self.tileset, self.sprite, math.floor(x), math.floor(y), r, s, s, 0, ox)
+		end
 	end
 end
 

--- a/entities/priorities.lua
+++ b/entities/priorities.lua
@@ -1,0 +1,33 @@
+local class = require('lib.middleclass')
+
+local priorities = class('priorities')
+
+-- basic: hauling, cleaning
+-- maintenance: repairing ship tiles and equipment
+-- duty: man a station
+-- doctor: heal the wounded
+-- food: cook meals, handle hydroponics(?)
+-- guard: stand guard
+-- 
+function priorities:initialize()
+
+	self.list = {
+		build = 3,
+		maintenance = 3,
+		duty = 3,
+		doctor = 3,
+		food = 3,
+		guard = 3,
+	}
+
+end
+
+function priorities:adjustPriority(pri, newPri)
+	self.list[pri] = newPri
+end
+
+function priorities:getPriority(pri)
+	return self.list[pri]
+end
+
+return priorities

--- a/entities/schedule.lua
+++ b/entities/schedule.lua
@@ -1,0 +1,44 @@
+local class = require('lib.middleclass')
+
+local schedule = class('schedule')
+
+--- sleep: 0, work: 1, play: 2, anything: 3
+function schedule:initialize()
+
+	self.list = {
+		0, -- Midnight to 1 AM
+		0, -- 1 AM to 2 AM
+		0, -- 2 AM to 3 AM
+		0, -- 3 AM to 4 AM
+		0, -- 4 AM to 5 AM
+		0, -- 5 AM to 6 AM
+		0, -- 6 AM to 7 AM
+		3, -- 7 AM to 8 AM
+		3, -- 8 AM to 9 AM
+		3, -- 9 AM to 10 AM
+		3, -- 10 AM to 11 AM
+		3, -- 11 AM to Noon
+		3, -- Noon to 1 PM
+		3, -- 1 PM to 2 PM
+		3, -- 2 PM to 3 PM
+		3, -- 3 PM to 4 PM
+		3, -- 4 PM to 5 PM
+		3, -- 5 PM to 6 PM
+		3, -- 6 PM to 7 PM
+		3, -- 7 PM to 8 PM
+		3, -- 8 PM to 9 PM
+		3, -- 9 PM to 10 PM
+		0, -- 10 PM to 11 PM
+		0, -- 11 PM to Midnight
+	}
+end
+
+function schedule:adjustHour(hour, newSchedule)
+	self.list[hour] = newSchedule
+end
+
+function schedule:getHour(hour)
+	return self.list[hour]
+end
+
+return schedule

--- a/furniture/door.lua
+++ b/furniture/door.lua
@@ -161,9 +161,9 @@ end
 
 function door:__tostring()
 	if self.open then
-		return "Door(".. self.name .."["..self.uid.."], " .. self.x .. ", " .. self.y .. ") (open)"
+		return "Door(".. self.label .."["..self.uid.."], " .. self.x .. ", " .. self.y .. ") (open)"
 	else
-		return "Door(".. self.name .."["..self.uid.."], " .. self.x .. ", " .. self.y .. ") (closed)"
+		return "Door(".. self.label .."["..self.uid.."], " .. self.x .. ", " .. self.y .. ") (closed)"
 	end
 end
 

--- a/furniture/furniture.lua
+++ b/furniture/furniture.lua
@@ -62,7 +62,7 @@ function furniture:initialize(name, map, posX, posY)
 		end
 	end
 
-	self.name = name
+	self.label = name
 	self.inventory = {}
 	self.output = {}
 	self.interactTiles = interactTiles
@@ -148,7 +148,7 @@ function furniture:isWalkable()
 end
 
 function furniture:__tostring()
-	return "Furniture(".. self.name .."["..self.uid.."], "..self.x..", "..self.y..")"
+	return "Furniture(".. self.label .."["..self.uid.."], "..self.x..", "..self.y..")"
 end
 
 return furniture

--- a/furniture/station.lua
+++ b/furniture/station.lua
@@ -86,7 +86,7 @@ function station:getViewStationTask(parentTask)
 	end
 
 	local function strFunc(tself)
-		return "Working on " .. self.name
+		return "Working on " .. self.label
 	end
 
 	local viewTask = task:new(nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, nil, parentTask)

--- a/furniture/station_default.lua
+++ b/furniture/station_default.lua
@@ -1,7 +1,7 @@
 local gamestate = require('gamestate.gamestate')
 
 local function loadFunc(sself, gstate, entity)
-	local str = entity.dname .. " is working on " .. sself.name
+	local str = entity.label .. " is working on " .. sself.label
 
 	gstate.topMargin = love.graphics.getHeight()*0.15
 	gstate.leftMargin = love.graphics.getWidth()*0.15

--- a/furniture/wall.lua
+++ b/furniture/wall.lua
@@ -18,7 +18,7 @@ function wall:isWall()
 end
 
 function wall:getType()
-	return furniture.getType(self) .. "[[wall]][[" .. self.name .. "]]"
+	return furniture.getType(self) .. "[[wall]][[" .. self.label .. "]]"
 end
 
 return wall

--- a/gamestate/gamestate_inventory.lua
+++ b/gamestate/gamestate_inventory.lua
@@ -9,10 +9,10 @@ function gamestate.static:getInventoryState(source, destination)
 			error("inventory state loaded with no source")
 		end
 
-		local str = "Viewing the contents of " .. source.name
+		local str = "Viewing the contents of " .. source.label
 
 		if destination then
-			str = destination.name .. " is viewing the contents of " .. source.name
+			str = destination.label .. " is viewing the contents of " .. source.label
 		end
 
 		gself.topMargin = love.graphics.getHeight()*0.15
@@ -42,10 +42,10 @@ function gamestate.static:getInventoryState(source, destination)
 		drawRect(gself.leftMargin, gself.topMargin, gself.width, gself.height)
 		love.graphics.print(gself.headerText, gself.headerPos, gself.topMargin + 20)
 		for i, item in ipairs(gself.items) do
-			love.graphics.print(item.name.."("..item.amount..")", gself.leftMargin + 20, gself.topMargin + 20 + (gself.textHeight + 5)*i)
+			love.graphics.print(item.label.."("..item.amount..")", gself.leftMargin + 20, gself.topMargin + 20 + (gself.textHeight + 5)*i)
 		end
 	end
 
-	local gs = gamestate:new("inventory for " .. source.name, loadFunc, nil, drawFunc, nil, inputFunc, false, true)
+	local gs = gamestate:new("inventory for " .. source.label, loadFunc, nil, drawFunc, nil, inputFunc, false, true)
 	return gs
 end

--- a/gamestate/gamestate_map.lua
+++ b/gamestate/gamestate_map.lua
@@ -3,7 +3,7 @@ local context = require('context')
 local furniture = require('furniture.furniture')
 local ghost = require('furniture.ghost')
 local hull = require('furniture.hull')
-local entity = require('entity')
+local entity = require('entities.entity')
 local data = require('data')
 
 -- TODO Maximum velocity for map movement, need to think about what to do about this and other basic constants
@@ -94,13 +94,6 @@ local function mousereleased(gself, x, y, button)
 			e:printTasks()
 		end
 	end
-
-	if button == 4 then
-		for i, r in ipairs(gself.map.rooms) do
-			print(i, #r.tiles)
-			r:listAttributes()
-		end
-	end
 end
 
 local function keysdown(gself)
@@ -136,7 +129,7 @@ function gamestate.static:getMapState(name, map, camera, passthrough)
 
 	local function loadFunc(gself)
 
-		gself.name = name
+		gself.label = name
 		gself.map = map
 		gself.map.camera = camera
 		gself.context = context:new(gself.map)

--- a/gamestate/gamestate_player.lua
+++ b/gamestate/gamestate_player.lua
@@ -1,0 +1,317 @@
+local class = require('lib.middleclass')
+local gamestate = require('gamestate.gamestate')
+local context = require('context')
+local camera = require('camera')
+local furniture = require('furniture.furniture')
+local ghost = require('furniture.ghost')
+local hull = require('furniture.hull')
+local entity = require('entities.entity')
+local data = require('data')
+
+local playerstate = class('playerstate', gamestate)
+
+function playerstate:initialize()
+
+	local c = camera:new()
+
+	self.label = "base playerstate"
+	self.camera = c
+	self.maps = {}
+	self.context = context:new(self)
+	self.currentMap = nil
+	self.ghost = nil
+	self.selection = nil
+	self.selectionBoxWidth = 300
+	self.selectionBoxHeight = 100
+	self.selectionBoxX = love.graphics.getWidth() - self.selectionBoxWidth
+	self.selectionBoxY = love.graphics.getHeight() - self.selectionBoxHeight
+	self.selectionBoxPadding = 10
+	self.selectionItems = 0
+
+	gamestate.initialize(self, "playerstate", nil, nil, nil, nil, nil, true, true)
+end
+
+function playerstate:update(dt)
+	if self.currentMap then
+		local rx, ry = getMousePos()
+		d:updateTextField("Tile under mouse", "")
+		d:updateTextField("Map under mouse", "")
+
+		local cnt = 0
+		for _, m in ipairs(self.maps) do
+			if m:inBounds(rx, ry) then
+				cnt = cnt + 1
+				d:updateTextField("Tile under mouse", tostring(self.currentMap:getTileAtWorld(rx, ry)))
+				d:updateTextField("Map under mouse", m.label .. " ("..cnt..")")
+			end
+		end
+
+		local objStr = ""
+		local objects = self.currentMap:getObjectsAtWorld(rx, ry)
+		for idx, obj in ipairs(objects) do
+			if idx ~= #objects then
+				objStr = objStr .. tostring(obj) .. ", "
+			else
+				objStr = objStr .. tostring(obj)
+			end
+		end
+		d:updateTextField("Objects under mouse", objStr)
+	end
+
+	if self.background then
+		self.background:update(dt)
+	end
+
+	self.context:update()
+
+	for _, map in ipairs(self.maps) do
+		map:update(dt)
+	end
+end
+
+function playerstate:draw()
+	if self.background then
+		self.background:draw()
+	end
+	for _, map in ipairs(self.maps) do
+		map:draw()
+	end
+
+	if self.selection then
+		self:drawSelectionBox()
+		self:drawSelectionDetails()
+	end
+	self:drawRoomDetails()
+
+	self.context:draw()
+end
+
+function playerstate:input(input)
+	self:keysdown()
+	if input.mousereleased then
+		self:mousereleased(input.mousereleased.x, input.mousereleased.y, input.mousereleased.button)
+	end
+	if input.keypressed then
+		self:keypressed(input.keypressed.key)
+	end
+	if input.wheelmoved then
+		self:wheelmoved(input.wheelmoved.x, input.wheelmoved.y)
+	end
+	if self.updateBelow and self.child then
+		self.child:inputFunc(input)
+	end
+end
+
+function playerstate:drawRoomDetails()
+	if self.currentMap then
+		local t = self.currentMap:getTileAtWorld(getMousePos())
+		if t then
+			local r = self.currentMap:inRoom(t.x, t.y)
+			if r then
+				local x = love.graphics.getWidth() - 200
+				local y = 20
+				drawRect(x, 20, 180, 100)
+				love.graphics.print("Room " .. r.uid, x + 10, y)
+				y = y + love.graphics.getFont():getHeight() + 2
+				if r.attributes then
+					for k, v in pairs(r.attributes) do
+						love.graphics.print(k..": "..fstr(v), x + 10, y)
+						y = y + love.graphics.getFont():getHeight() + 2
+					end
+				end
+			end
+		end
+	end
+end
+
+function playerstate:drawSelectionBox()
+	if self.selection:isType('stockpile') then
+		self.selection:draw()
+	else
+		rect("line", self.selection:getWorldX(), self.selection:getWorldY(),
+					self.selection.spriteWidth, self.selection.spriteHeight, self.camera)
+	end
+end
+
+function playerstate:drawSelectionDetails()
+
+	drawRect(self.selectionBoxX -self.selectionBoxPadding,
+	self.selectionBoxY - self.selectionBoxPadding,
+	self.selectionBoxWidth, self.selectionBoxHeight)
+	self.detailIndex = 0
+
+	self:addSelectionDetailText(self.selection.label .."["..self.selection.uid.."]")
+
+	if self.selection:isType("entity") then
+		local tlist = self.selection:getTasks()
+		local itemNum = 1
+		local idleSeconds = math.floor(self.selection.idleTime/60)
+		if idleSeconds > 0 then
+			self:addSelectionDetailText("Idle for " .. idleSeconds .. " seconds")
+		end
+		self:addSelectionDetailText("Health: " .. self.selection.health)
+		self:addSelectionDetailText("Satiation: " .. self.selection.satiation)
+		self:addSelectionDetailText("Comfort: " .. fstr(self.selection.comfort))
+		self:addSelectionDetailText("Oxy Starv: " .. fstr(self.selection.oxygenStarvation, 0))
+
+		for i=#tlist, 1, -1 do
+			if not tlist[i]:isChild() then
+				self:addSelectionDetailText(tlist[i]:getDesc())
+			end
+		end
+	elseif self.selection:isType("stockpile") then
+		for i, item in ipairs(self.selection.contents) do
+			self:addSelectionDetailText(item.label .. "(" ..item.uid..") " .. #self.selection.contents)
+		end
+	end
+end
+
+function playerstate:addSelectionDetailText(str)
+	local f = love.graphics.getFont()
+	local x, idx = 0, self.detailIndex
+	if self.detailIndex > 5 then
+		x = self.selectionBoxWidth/2
+		idx = self.detailIndex % 6
+	end
+	love.graphics.print(str, self.selectionBoxX + x, self.selectionBoxY + f:getHeight()*idx)
+	self.detailIndex = self.detailIndex + 1
+end
+
+function playerstate:wheelmoved(x, y)
+	if y > 0 then
+		for i=1, y do
+			self.camera:zoomIn()
+		end
+	elseif y < 0 then
+		for i=1, math.abs(y) do
+			self.camera:zoomOut()
+		end
+	end
+end
+
+function playerstate:keypressed(key)
+	local t, e, i, f, s
+	if self.currentMap then
+		t = self.currentMap:getTileAtWorld(getMousePos())
+		e = self.currentMap:getEntitiesAtWorld(getMousePos())[1]
+		i = self.currentMap:getItemsAtWorld(getMousePos())[1]
+		f = self.currentMap:getFurnitureAtWorld(getMousePos())[1]
+		s = self.currentMap:getStockpileAtWorld(getMousePos())
+	end
+	if key =='g' and e then
+		e:die()
+	end
+
+	if key == 'f' and t then
+		local ent = entity:new("pawn", data:getBase():getRandomFullName(), self.currentMap, t.x - self.currentMap.xOffset, t.y - self.currentMap.yOffset)
+		self.currentMap:addEntity(ent)
+	end
+end
+
+function playerstate:mousereleased(x, y, button)
+	local t, objects
+	if self.currentMap then
+		t = self.currentMap:getTileAtWorld(getMousePos())
+		objects = self.currentMap:getObjectsAtWorld(getMousePos())
+	end
+	if not self.ct then self.ct = t end
+	if not self.cti then self.cti = 1 end
+
+	if button == 1 then
+		local thisMap = self.currentMap
+		for _, m in ipairs(self.maps) do
+			if m:inBounds(getMousePos()) and (not thisMap or m.uid ~= thisMap.uid) then
+				self:setCurrentMap(m)
+				self:clearSelection()
+				thisMap = false
+				break
+			end
+		end
+		if thisMap then
+			local msg = self.currentMap.alert:inBounds(x, y)
+			if msg then
+				self.currentMap.alert:removeAlert(msg)
+			elseif self.context.active and self.context:inBounds(x, y) then
+				self.context:handleClick(x, y)
+			elseif #objects > 0 then
+				if self.ct.uid == t.uid then
+					if self.cti < #objects then
+						self:setSelection(objects[self.cti])
+						self.cti = self.cti + 1
+					elseif self.cti == #objects then
+						self:setSelection(objects[self.cti])
+						self.cti = 1
+					else
+						self.cti = 1
+						self:setSelection(objects[self.cti])
+					end
+				else
+					self.cti = 2
+					self.ct = t
+					self:setSelection(objects[1])
+				end
+			end
+		end
+	end
+
+	if button == 2 then
+		local selection = self:getSelection()
+		if selection and t and selection:isType("entity") and selection.map.uid == self.currentMap.uid then
+			local tlist = self.currentMap:getPossibleTasks(t, selection)
+			self.context:set(x, y, tlist)
+		end
+	end
+
+end
+
+function playerstate:keysdown()
+	if love.keyboard.isDown('w') then
+		self.camera:moveYOffset(5*self.camera.scale)
+	end
+	if love.keyboard.isDown('a') then
+		self.camera:moveXOffset(5*self.camera.scale)
+	end
+	if love.keyboard.isDown('s') then
+		self.camera:moveYOffset(-5*self.camera.scale)
+	end
+	if love.keyboard.isDown('d') then
+		self.camera:moveXOffset(-5*self.camera.scale)
+	end
+end
+
+function playerstate:addMap(map)
+	map.camera = self.camera
+	table.insert(self.maps, map)
+end
+
+function playerstate:setCurrentMap(map)
+	if self.currentMap then self.currentMap:unselect() end
+	self.currentMap = map
+	self.currentMap.camera = self.camera
+	self.currentMap:select()
+end
+
+function playerstate:setSelection(obj)
+	if self.selection then
+		self.selection:deselect()
+	end
+	obj:select()
+	self.selection = obj
+end
+
+function playerstate:clearSelection()
+	if self.selection then
+		self.selection:deselect()
+	end
+	self.selection = nil
+end
+
+function playerstate:getSelection()
+	return self.selection
+end
+
+function playerstate:getContext()
+	return self.context
+end
+
+return playerstate

--- a/gamestate/gamestate_station.lua
+++ b/gamestate/gamestate_station.lua
@@ -25,6 +25,6 @@ function gamestate.static:getStationState(station, entity)
 		station:exitFunc(gself, entity)
 	end
 
-	local gs = gamestate:new("view station " .. station.name, loadFunc, updateFunc, drawFunc, exitFunc, inputFunc, true, true)
+	local gs = gamestate:new("view station " .. station.label, loadFunc, updateFunc, drawFunc, exitFunc, inputFunc, true, true)
 	return gs
 end

--- a/items/corpse.lua
+++ b/items/corpse.lua
@@ -15,11 +15,11 @@ function corpse:initialize(objClass, name, map, posX, posY)
 
 	self.maxStack = 1
 	self.amount = 1
-	self.name = name
+	self.label = name
 	self.map = map
 
-	self.originTileWidth = self.tileWidth
-	self.originTileHeight = self.tileHeight
+	self.originTileWidth = self.width
+	self.originTileHeight = self.height
 	self.originSpriteWidth = self.spriteWidth
 	self.originSpriteHeight = self.spriteHeight
 	self.originXOffset = self.xOffset
@@ -31,21 +31,23 @@ function corpse:initialize(objClass, name, map, posX, posY)
 	self.height = self.originTileWidth
 	self.spriteWidth = self.originSpriteHeight
 	self.spriteHeight = self.originSpriteWidth
-	self.xOffset = self.originYOffset
-	self.yOffset = self.originXOffset
 end
 
-function corpse:draw()
+function corpse:draw(ent)
 	local c = self.map.camera
-	local x = c:getRelativeX(self:getWorldX() + self.originSpriteHeight)
-	local y = c:getRelativeY(self:getWorldY() + self.originSpriteWidth - TILE_SIZE)
+	local x, y
+	if ent then
+		x = c:getRelativeX(ent:getWorldX())
+		y = c:getRelativeY(ent:getWorldY())
+	else
+		x = c:getRelativeX(self:getWorldX())
+		y = c:getRelativeY(self:getWorldY())
+	end
 	mapObject.draw(self, x, y, c.scale, math.pi/2)
 end
 
 function corpse:removedFromInventory(entity)
 	item.removedFromInventory(self, entity)
-	self.xOffset = self.originYOffset
-	self.yOffset = self.originXOffset
 end
 
 return corpse

--- a/items/item.lua
+++ b/items/item.lua
@@ -42,16 +42,22 @@ function item:initialize(name, map, posX, posY, amount, maxStack)
 	amount = amount or 1
 	maxStack = maxStack or 50
 
-	self.name = name
+	self.label = name
 	self.map = map
 	self.amount = amount
 	self.maxStack = maxStack
 end
 
-function item:draw()
+function item:draw(ent)
 	local c = self.map.camera
-	local x = c:getRelativeX(self:getWorldX())
-	local y = c:getRelativeY(self:getWorldY())
+	local x, y
+	if ent then
+		x = c:getRelativeX(ent:getWorldX())
+		y = c:getRelativeY(ent:getWorldY())
+	else
+		x = c:getRelativeX(self:getWorldX())
+		y = c:getRelativeY(self:getWorldY())
+	end
 	mapObject.draw(self, x, y, c.scale)
 	if self.amount > 1 then
 		drawable.drawSubText(self, self.amount, x, y, c.scale)
@@ -65,7 +71,6 @@ function item:removedFromInventory(entity)
 	self.y = entity.y
 	self.xOffset = self.origXOffset
 	self.yOffset = self.origYOffset
-	--self:addedToTile()
 end
 
 function item:addedToInventory(entity)
@@ -88,15 +93,9 @@ function item:addedToTile()
 			local tmp = self:mergeWith(mapItem)
 			if tmp ~= 0 then
 				local t = self.map:getRandomWalkableTileInRadius(self.x, self.y, 1)
-				if self.amount > mapItem.amount then
-					mapItem.x = t.x
-					mapItem.y = t.y
-					mapItem:addedToTile()
-				else
-					self.x = t.x
-					self.y = t.y
-					self:addedToTile()
-				end
+				self.x = t.x
+				self.y = t.y
+				self:addedToTile()
 			end
 		end
 	end
@@ -121,11 +120,11 @@ end
 
 function item:split(amt)
 	if self.amount >= amt then
-		local tmp = self:getClass():new(self.name, self.map, self.x, self.y, amt, self.maxStack)
+		local tmp = self:getClass():new(self.label, self.map, self.x, self.y, amt, self.maxStack)
 		self:adjustAmount(-amt)
 		return tmp
 	else
-		print("failed split")
+		print(string.format("tried to split %s into an amount greater than its total (%d > %d)", self.label, amt, self.amount))
 		return false
 	end
 end
@@ -141,48 +140,67 @@ end
 
 function item:getAvailableJobs()
 	local tasks = {}
-
-	local sp = self.map:checkStockpileAvailableFor(self)
-	if sp and not sp:inStockpile(self) then
-		local function startFunc(tself)
-			local t = sp:getAvailableTileFor(self)
-			if t then
-				local p = tself:getParams()
-				p.pickup = pickupTask:new(self, tself)
-				p.drop = dropTask:new(self, t, tself)
-				p.dest = t
-				if not self.owned then
-					tself.entity:pushTask(p.drop)
-					tself.entity:pushTask(p.pickup)
+	if not self:isReserved() then
+		local sp = self.map:checkStockpileAvailableFor(self)
+		if sp and not sp:inStockpile(self) then
+			local function startFunc(tself)
+				local t = sp:getAvailableTileFor(self)
+				if t then
+					local p = tself:getParams()
+					self:reserveFor(tself.entity)
+					t:reserveFor(tself.entity)
+					p.pickup = pickupTask:new(self, tself)
+					p.drop = dropTask:new(self, t, tself)
+					p.dest = t
+					if not self.owned then
+						tself.entity:pushTask(p.drop)
+						tself.entity:pushTask(p.pickup)
+					else
+						tself.entity:pushTask(p.drop)
+					end
 				else
-					tself.entity:pushTask(p.drop)
+					tself:abandon()
+					tself:complete()
 				end
-			else
-				tself:abandon()
-				tself:complete()
 			end
-		end
 
-		local function runFunc(tself)
-			local p = tself:getParams()
-			if p.dropped then
-				tself:complete()
+			local function abandonFunc(tself)
+				local p = tself:getParams()
+				self:unreserve(tself.entity)
+				if p.dest then
+					p.dest:unreserve(tself.entity)
+				end
 			end
-		end
 
-		local function strFunc(tself)
-			local p = tself:getParams()
-			if not p.dropped and p.dest then
-				return "Hauling " .. self.name .. " to tile (".. p.dest.x ..", "..p.dest.y..")"
-			else
-				return ""
+			local function endFunc(tself)
+				local p = tself:getParams()
+				if p.dest then
+					p.dest:unreserve(tself.entity)
+				end
 			end
-		end
 
-		local haulTask = task:new(nil, nil, strFunc, nil, startFunc, runFunc, nil, nil, nil)
-		table.insert(tasks, haulTask)
+			local function runFunc(tself)
+				local p = tself:getParams()
+				if p.dropped then
+					self:unreserve(tself.entity)
+					p.dest:unreserve(tself.entity)
+					tself:complete()
+				end
+			end
+
+			local function strFunc(tself)
+				local p = tself:getParams()
+				if not p.dropped and p.dest then
+					return "Hauling " .. self.label .. " to tile (".. p.dest.x ..", "..p.dest.y..")"
+				else
+					return ""
+				end
+			end
+
+			local haulTask = task:new(nil, nil, strFunc, nil, startFunc, runFunc, endFunc, abandonFunc, nil)
+			table.insert(tasks, haulTask)
+		end
 	end
-
 	return tasks
 end
 
@@ -197,15 +215,8 @@ function item:getPossibleTasks()
 	return tasks
 end
 
-function item:setPos(x, y, xOffset, yOffset)
-	self.x = x
-	self.y = y
-	self.xOffset = xOffset
-	self.yOffset = yOffset
-end
-
 function item:getType()
-	return drawable.getType(self) .. "[[item]][[" .. self.name .. "]]"
+	return drawable.getType(self) .. "[[item]][[" .. self.label .. "]]"
 end
 
 function item:getClass()
@@ -213,11 +224,11 @@ function item:getClass()
 end
 
 function item:getPluralName()
-	return self.name + "s"
+	return self.label + "s"
 end
 
 function item:__tostring()
-	return "Item(".. self.amount .. " of " .. self.name .."["..self.uid.."], "..self.x..", "..self.y..")"
+	return "Item(".. self.amount .. " of " .. self.label .."["..self.uid.."], "..self.x..", "..self.y..")"
 end
 
 return item

--- a/map/map_utils.lua
+++ b/map/map_utils.lua
@@ -225,8 +225,17 @@ local map_utils = {
 		for _, f in ipairs(self:getFurnitureInTile(tile)) do
 			table.insert(objects, f)
 		end
+		for _, s in ipairs(self.stockpiles) do
+			if s:inTile(tile) then
+				table.insert(objects, s)
+			end
+		end
 
 		return objects
+	end,
+
+	getCentermostTile = function(self)
+		return self:getTile(math.floor(self.width/2), math.floor(self.height/2))
 	end,
 
 	getRandomWalkableTile = function(self)
@@ -290,7 +299,7 @@ local map_utils = {
 	getTilesFromPoints = function(self, points)
 		local tiles = {}
 		for _, point in ipairs(points) do
-			local t = self:getTile(point.x, point.y)
+			local t = self:getTile(point.x + self.xOffset, point.y + self.yOffset)
 			if t then
 				table.insert(tiles, t)
 			end

--- a/mapObject.lua
+++ b/mapObject.lua
@@ -79,14 +79,17 @@ function mapObject:unreserve(obj)
 		self.reserved = false
 		self.reservedFor = nil
 		return true
-	else
-		return false
 	end
+	if self.reservedFor then
+		print("ERR: attempted to unreserve "..self.label.." for "..obj.label.." but was reserved for "..self.reservedFor.label)
+	end
+	return false
 end
 
 function mapObject:reserveFor(obj)
 	self.reserved = true
 	self.reservedFor = obj
+	return true
 end
 
 function mapObject:isReserved()

--- a/tasks/task_entity_sit.lua
+++ b/tasks/task_entity_sit.lua
@@ -49,20 +49,28 @@ end
 
 local function endFunc(self)
 	local p = self:getParams()
-	p.reachedSeat = true
 	self.furniture:unreserve(self.entity)
+	if not self.abandoned then
+		p.reachedSeat = true
+	end
+end
+
+local function abandonFunc(self)
+	if self:isChild() then
+		self.parent:abandon()
+	end
 end
 
 local function strFunc(self)
 	if self.entity.walking then
-		return "Moving to (" .. self.entity.destination.x .. ", " .. self.entity.destination.y .. ") to sit on " .. self.furniture.name
+		return "Moving to (" .. self.entity.destination.x .. ", " .. self.entity.destination.y .. ") to sit on " .. self.furniture.label
 	else
-		return "Sitting on " .. self.furniture.name
+		return "Sitting on " .. self.furniture.label
 	end
 end
 
 local function contextFunc(self)
-	return "Sit on " .. self.furniture.name
+	return "Sit on " .. self.furniture.label
 end
 
 function sitTask:initialize(furniture, parentTask)
@@ -70,7 +78,7 @@ function sitTask:initialize(furniture, parentTask)
 	if not furniture:isType("comfort") then error("sitTask initialized with unsittable furniture") end
 
 	self.furniture = furniture
-	task.initialize(self, nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, nil, parentTask)
+	task.initialize(self, nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, abandonFunc, parentTask)
 end
 
 return sitTask

--- a/tasks/task_entity_walk.lua
+++ b/tasks/task_entity_walk.lua
@@ -37,6 +37,9 @@ local function abandonFunc(self)
 		for i=1, count do self.entity.route[i]=nil end
 		table.insert(self.entity.route, nextRoute)
 	end
+	if self:isChild() then
+		self.parent:abandon()
+	end
 end
 
 local function contextFunc(self)

--- a/tasks/task_furniture_deposit.lua
+++ b/tasks/task_furniture_deposit.lua
@@ -41,11 +41,11 @@ local function endFunc(self)
 end
 
 local function contextFunc(self)
-	return "Put " .. self.item.name .. " in " .. self.furniture.name
+	return "Put " .. self.item.label .. " in " .. self.furniture.label
 end
 
 local function strFunc(self)
-	return "Putting " .. self.item.name .. " in " .. self.furniture.name
+	return "Putting " .. self.item.label .. " in " .. self.furniture.label
 end
 
 function depositTask:initialize(item, furniture, parentTask)

--- a/tasks/task_furniture_view_contents.lua
+++ b/tasks/task_furniture_view_contents.lua
@@ -55,7 +55,7 @@ local function contextFunc(self)
 end
 
 local function strFunc(self)
-	return "Viewing the inventory of " .. self.furniture.name
+	return "Viewing the inventory of " .. self.furniture.label
 end
 
 function viewContentsTask:initialize(furniture, parentTask)

--- a/tasks/task_furniture_withdraw.lua
+++ b/tasks/task_furniture_withdraw.lua
@@ -40,11 +40,11 @@ local function endFunc(self)
 end
 
 local function contextFunc(self)
-	return "Take " .. self.item.name .. " from " .. self.furniture.name
+	return "Take " .. self.item.label .. " from " .. self.furniture.label
 end
 
 local function strFunc(self)
-	return "Taking " .. self.item.name .. " from " .. self.furniture.name
+	return "Taking " .. self.item.label .. " from " .. self.furniture.label
 end
 
 function withdrawTask:initialize(furniture, item, parentTask)

--- a/tasks/task_item_drop.lua
+++ b/tasks/task_item_drop.lua
@@ -40,15 +40,23 @@ local function endFunc(self)
 		if s then
 			s:addToStockpile(self.item)
 		end
+	elseif self:isChild() then
+		self.parent:abandon()
+	end
+end
+
+local function abandonFunc(self)
+	if self:isChild() then
+		self.parent:abandon()
 	end
 end
 
 local function contextFunc(self)
-	return "Drop " .. self.item.name
+	return "Drop " .. self.item.label
 end
 
 local function strFunc(self)
-	return "Dropping " .. self.item.name
+	return "Dropping " .. self.item.label
 end
 
 function dropTask:initialize(item, destination, parentTask)
@@ -57,7 +65,7 @@ function dropTask:initialize(item, destination, parentTask)
 
 	self.item = item
 	self.destination = destination
-	task.initialize(self, nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, nil, parentTask)
+	task.initialize(self, nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, abandonFunc, parentTask)
 end
 
 return dropTask

--- a/tasks/task_item_pickup.lua
+++ b/tasks/task_item_pickup.lua
@@ -36,19 +36,25 @@ local function endFunc(self)
 	end
 end
 
+local function abandonFunc(self)
+	if self:isChild() then
+		self.parent:abandon()
+	end
+end
+
 local function strFunc(self)
-	return "Moving to (" .. self.item.x .. ", " .. self.item.y .. ") to pick up " .. self.item.name
+	return "Moving to (" .. self.item.x .. ", " .. self.item.y .. ") to pick up " .. self.item.label
 end
 
 local function contextFunc(self)
-	return "Pick up " .. self.item.name
+	return "Pick up " .. self.item.label
 end
 
 function pickupTask:initialize(item, parentTask)
 	if not item then error("pickupTask initialized with no item") end
 
 	self.item = item
-	task.initialize(self, nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, nil, parentTask)
+	task.initialize(self, nil, contextFunc, strFunc, nil, startFunc, runFunc, endFunc, abandonFunc, parentTask)
 end
 
 return pickupTask


### PR DESCRIPTION
Playerstate can have multiple maps attached
You can click on a map in the game view to select
Maps that aren't selected only draw tiles, not objects (temporary, to
	be replaced with a roof later)
Moved everything about mouse selection out of map and into playerstate
Moved context menu handling into playerstate
Moved entity.lua to its own directory
Added very basic schedule and priorities classes
Reworked and debugged how corpses are drawn
Fixed some bugs with negative map offsets
Fixed a ton of bugs with how hauling works
Attempted to standarize everything to use 'label' instead of 'name'
'name' is still used for tilesets
Made most tasks better about reserving and unreserving anything they use
Some misc. helper functions and fixes